### PR TITLE
Add bash script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,4 @@ ASALocalRun/
 healthchecksdb
 /Dumplings.Cli/Properties/launchSettings.json
 /Dumplings.Cli/Scanner
+/Dumplings.Cli/Config.txt

--- a/Dumplings.Cli/RunAndSendDumplings.sh
+++ b/Dumplings.Cli/RunAndSendDumplings.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+FILE1='LastProcessedBlockHeight.txt'
+FILE2='OtherCoinJoins.txt'
+FILE3='SamouraiPostMixTxs.txt'
+FILE4='OtherCoinJoinPostMixTxs.txt'
+FILE5='SamouraiCoinJoins.txt'
+FILE6='SamouraiTx0s.txt'
+FILE7='WabiSabiCoinJoins.txt'
+FILE8='WasabiPostMixTxs.txt'
+FILE9='WasabiCoinJoins.txt'
+
+# Make sure to have 'Config.txt' in the same file as this script.
+# The following variables need to be imported from the config file:
+
+# HOST = FTP server address,
+# FTPUSER & FTPPASSWD = FTP login credentials,
+# RPCUSER & RPCPASSWD = RPC credentials for Bitcoin Kntos,
+# OLDCORDXPUB(two keys, divided by ',') & WABISABIXPUB = Coordinator XPUBs,
+# OUTFOLDER = Where to save processed dumplings,
+# SCANNERFOLDER = Where to look for the coinjoin stat files to send
+
+source Config.txt
+
+echo "Syncronizing blockchain"
+dotnet run -c Release -- sync --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWD --nowaitonexit
+
+echo "Processing Wasabi Coordinator Stats"
+dotnet run -c Release -- WasabiCoordStats --xpub=$OLDCORDXPUB --outfolder=$OUTFOLDER --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWD --nowaitonexit
+
+echo "Processing WabiSabi Coordinator Stats"
+dotnet run -c Release -- WabiSabiCoordStats --xpub=$WABISABIXPUB --outfolder=$OUTFOLDER --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWD --nowaitonexit
+
+cd $SCANNERFOLDER
+
+echo "Starting FTP upload"
+
+ftp -n $HOST <<END_SCRIPT
+quote USER $FTPUSER
+quote PASS $FTPPASSWD
+put $FILE1
+put $FILE2
+put $FILE3
+put $FILE4
+put $FILE5
+put $FILE6
+put $FILE7
+put $FILE8
+put $FILE9
+quit
+END_SCRIPT
+
+echo "Finished"

--- a/Dumplings.Cli/RunAndSendDumplings.sh
+++ b/Dumplings.Cli/RunAndSendDumplings.sh
@@ -15,20 +15,12 @@ FILE9='WasabiCoinJoins.txt'
 # HOST = FTP server address,
 # FTPUSER & FTPPASSWD = FTP login credentials,
 # RPCUSER & RPCPASSWD = RPC credentials for Bitcoin Kntos,
-# OLDCORDXPUB(two keys, divided by ',') & WABISABIXPUB = Coordinator XPUBs,
-# OUTFOLDER = Where to save processed dumplings,
 # SCANNERFOLDER = Where to look for the coinjoin stat files to send
 
 source Config.txt
 
 echo "Syncronizing blockchain"
 dotnet run -c Release -- sync --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWD --nowaitonexit
-
-echo "Processing Wasabi Coordinator Stats"
-dotnet run -c Release -- WasabiCoordStats --xpub=$OLDCORDXPUB --outfolder=$OUTFOLDER --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWD --nowaitonexit
-
-echo "Processing WabiSabi Coordinator Stats"
-dotnet run -c Release -- WabiSabiCoordStats --xpub=$WABISABIXPUB --outfolder=$OUTFOLDER --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWD --nowaitonexit
 
 cd $SCANNERFOLDER
 

--- a/Dumplings.Cli/RunAndSendDumplings.sh
+++ b/Dumplings.Cli/RunAndSendDumplings.sh
@@ -24,6 +24,10 @@ dotnet run -c Release -- sync --rpcuser=$RPCUSER --rpcpassword=$RPCPASSWD --nowa
 
 cd $SCANNERFOLDER
 
+cat > UPDATEREADY.txt << EOF
+true
+EOF
+
 echo "Starting FTP upload"
 
 ftp -n $HOST <<END_SCRIPT
@@ -38,7 +42,20 @@ put $FILE6
 put $FILE7
 put $FILE8
 put $FILE9
+put UPDATEREADY.txt
 quit
 END_SCRIPT
 
-echo "Finished"
+echo "Finished FTP upload!"
+echo "Removing files"
+rm $FILE2
+rm $FILE3
+rm $FILE4
+rm $FILE5
+rm $FILE6
+rm $FILE7
+rm $FILE8
+rm $FILE9
+rm UPDATEREADY.txt
+
+echo "Files removed!"


### PR DESCRIPTION
Adding bash script to run scheduled.
If Bitcoin Knots is running & syncronized:
- It runs the Dumplings with the `sync` command to get the Scanner files
- It sends the scanned coinjoin files to an FTP server for further processing