### PR TITLE
Add File exists check method to scanner

### DIFF
--- a/Dumplings/Scanning/Scanner.cs
+++ b/Dumplings/Scanning/Scanner.cs
@@ -318,35 +318,44 @@ namespace Dumplings.Scanning
 
         private static IEnumerable<VerboseTransactionInfo> ReadWasabiCoinJoins()
         {
-            return File.ReadAllLines(WasabiCoinJoinsPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(WasabiCoinJoinsPath);
         }
         private static IEnumerable<VerboseTransactionInfo> ReadSamouraiCoinJoins()
         {
-            return File.ReadAllLines(SamouraiCoinJoinsPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(SamouraiCoinJoinsPath);
         }
         private static IEnumerable<VerboseTransactionInfo> ReadOtherCoinJoins()
         {
-            return File.ReadAllLines(OtherCoinJoinsPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(OtherCoinJoinsPath);
         }
         private static IEnumerable<VerboseTransactionInfo> ReadSamouraiTx0s()
         {
-            return File.ReadAllLines(SamouraiTx0sPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(SamouraiTx0sPath);
         }
         private static IEnumerable<VerboseTransactionInfo> ReadWasabiPostMixTxs()
         {
-            return File.ReadAllLines(WasabiPostMixTxsPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(WasabiPostMixTxsPath);
         }
         private static IEnumerable<VerboseTransactionInfo> ReadSamouraiPostMixTxs()
         {
-            return File.ReadAllLines(SamouraiPostMixTxsPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(SamouraiPostMixTxsPath);
         }
         private static IEnumerable<VerboseTransactionInfo> ReadOtherCoinJoinPostMixTxs()
         {
-            return File.ReadAllLines(OtherCoinJoinPostMixTxsPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(OtherCoinJoinPostMixTxsPath);
         }
         private static IEnumerable<VerboseTransactionInfo> ReadWabiSabiCoinJoins()
         {
-            return File.ReadAllLines(WabiSabiCoinJoinsPath).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            return CheckAndReadIfExists(WabiSabiCoinJoinsPath);
+        }
+
+        private static IEnumerable<VerboseTransactionInfo> CheckAndReadIfExists(string path)
+        {
+            if(File.Exists(path))
+            {
+                return File.ReadAllLines(path).Select(x => RpcParser.VerboseTransactionInfoFromLine(x));
+            }
+            return Enumerable.Empty<VerboseTransactionInfo>();
         }
 
         private static ulong ReadBestHeight()


### PR DESCRIPTION
As we are removing the old coinjoin files, so at the FTP end Norbi don't have to process all the already processed lines again, the `sync` command can fail and throw an exception, as it is trying to read from files that doesn't exist no more.
This adds a small check to these `ReadLines` methods.