### PR TITLE
Add Taproot check

### DIFF
--- a/Dumplings.Cli/GetAndSendWWCoordStats.sh
+++ b/Dumplings.Cli/GetAndSendWWCoordStats.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 
 # exit when any command fails
 set -e

--- a/Dumplings/Scanning/Scanner.cs
+++ b/Dumplings/Scanning/Scanner.cs
@@ -129,7 +129,7 @@ namespace Dumplings.Scanning
                             if (block.Height >= Constants.FirstWasabi2Block)
                             {
                                 isWasabi2Cj =
-                                    isNativeSegwitOnly
+                                    tx.Inputs.All(x => x.PrevOutput.ScriptPubKey.IsScriptType(ScriptType.P2WPKH) || x.PrevOutput.ScriptPubKey.IsScriptType(ScriptType.Taproot))
                                     && inputCount >= 50 // 50 was the minimum input count at the beginning of Wasabi 2.
                                     && inputValues.SequenceEqual(inputValues.OrderByDescending(x => x)) // Inputs are ordered descending.
                                     && outputValues.SequenceEqual(outputValues.OrderByDescending(x => x)) // Outputs are ordered descending.


### PR DESCRIPTION
Dumplings was working nicely and was giving back good data since this fix has been added, lets merge it to outfolder.

ccf350e5aa76d59b5b5868f6af503c101498b56a: Saving the script with correct chmod permissions (775)
ad118a458120598e862e0ccc9e11fc54b79b97f8: The actual fix, adding Taproot checking instead of Segwit only.