### PR TITLE
Log start of `CheckDuplications`, as these are sometimes slow

### DIFF
--- a/Dumplings/Checking/Checker.cs
+++ b/Dumplings/Checking/Checker.cs
@@ -82,6 +82,7 @@ namespace Dumplings.Checking
 
         private void CheckDuplications(IEnumerable<uint256> txs, string where)
         {
+            Logger.LogInfo($"Starting CheckDuplications for {where}.");
             var txids = txs.ToArray();
             var duplicated = new HashSet<uint256>();
             for (int i = 0; i < txids.Length; i++)


### PR DESCRIPTION
Otherwise by following log output one might think Dumplings has hanged as there is no feedback it is in this potentially long running code.